### PR TITLE
Prevent horses fitness from degradation on Seasons

### DIFF
--- a/additionals/GC_HorseHelper.lua
+++ b/additionals/GC_HorseHelper.lua
@@ -64,10 +64,11 @@ function GC_HorseHelper:hourChanged()
 						if animal.subType ~= nil and animal.subType.livery ~= nil and animal.subType.livery.income  ~= nil then
 							price = animal.subType.livery.income * 0.3;
 							animal.ridingScale = 1;
-						else							
-							animal.ridingTimerSent  = animal.DAILY_TARGET_RIDING_TIME;
-							animal.ridingTimer  = animal.DAILY_TARGET_RIDING_TIME;
 						end;
+
+						--horse fitness should be updated regardless of Seasons
+						animal.ridingTimerSent = animal.DAILY_TARGET_RIDING_TIME;
+						animal.ridingTimer = animal.DAILY_TARGET_RIDING_TIME;
 
 						moneyToOwner[farmId] = moneyToOwner[farmId] + price;
 					end;


### PR DESCRIPTION
When using _Seasons_ with _Global Company_, Horse Helper feature doesn't work as intended. At 11pm the horse helper fee is subtracted from the player account, but fitness is left unchanged.
This simple fix ensures that "Daily raiding" is set to 100% (or any number defined as `DAILY_TARGET_RIDING_TIME`).

Fix was tested on many days during my own playthrough.

Resolves #132.

Idea looked up on Steam forum: https://steamcommunity.com/app/787860/discussions/0/2143091512086827554/#c2272575584120126954